### PR TITLE
fix: 修复macOS arm64编译失败

### DIFF
--- a/QFluent/src/QFluent/SpinBox.cpp
+++ b/QFluent/src/QFluent/SpinBox.cpp
@@ -3,7 +3,6 @@
 #include <QMenu>
 #include <QLineEdit>
 #include <QHBoxLayout>
-#include <QPainter>
 #include <QPainterPath>
 #include <QStyleOption>
 #include <QContextMenuEvent>
@@ -14,11 +13,6 @@
 #include "FluentIcon.h"
 #include "StyleSheet.h"
 
-template class InlineSpinBoxBase<QSpinBox>;
-template class InlineSpinBoxBase<QDoubleSpinBox>;
-template class InlineSpinBoxBase<QTimeEdit>;
-template class InlineSpinBoxBase<QDateTimeEdit>;
-template class InlineSpinBoxBase<QDateEdit>;
 
 // --- SpinButton ---
 
@@ -181,43 +175,4 @@ void SpinBoxBase::drawFocusBorder(QPainter *painter, const QRect &rect)
     path = path.subtracted(rectPath);
 
     painter->fillPath(path, Theme::themeColor(Fluent::ThemeColor::PRIMARY));
-}
-
-// --- InlineSpinBoxBase ---
-
-template <typename T>
-InlineSpinBoxBase<T>::InlineSpinBoxBase(QWidget *parent)
-    : T(parent)
-    , m_helper(new SpinBoxBase(this))
-{
-    m_helper->addUpDownButtons();
-    m_helper->setup();
-}
-
-template <typename T>
-void InlineSpinBoxBase<T>::setError(bool isError)
-{
-    m_helper->setError(isError);
-}
-
-template <typename T>
-bool InlineSpinBoxBase<T>::isError() const
-{
-    return m_helper->isError();
-}
-
-template <typename T>
-void InlineSpinBoxBase<T>::setSymbolVisible(bool visible)
-{
-    m_helper->setSymbolVisible(visible);
-}
-
-template <typename T>
-void InlineSpinBoxBase<T>::paintEvent(QPaintEvent *event)
-{
-    T::paintEvent(event);
-    if (this->hasFocus() && !isError()) {
-        QPainter painter(this);
-        m_helper->drawFocusBorder(&painter, this->rect());
-    }
 }

--- a/QFluent/src/QFluent/SpinBox.h
+++ b/QFluent/src/QFluent/SpinBox.h
@@ -7,6 +7,7 @@
 #include <QDateTimeEdit>
 #include <QToolButton>
 #include <QPointer>
+#include <QPainter>
 #include <QScopedPointer>
 
 #include "FluentGlobal.h"
@@ -126,3 +127,41 @@ public:
     using Base = InlineSpinBoxBase<QDateEdit>;
     using Base::Base;
 };
+
+template <typename T>
+InlineSpinBoxBase<T>::InlineSpinBoxBase(QWidget *parent)
+    : T(parent)
+    , m_helper(new SpinBoxBase(this))
+{
+    m_helper->addUpDownButtons();
+    m_helper->setup();
+}
+
+template <typename T>
+void InlineSpinBoxBase<T>::setError(bool isError)
+{
+    m_helper->setError(isError);
+}
+
+template <typename T>
+bool InlineSpinBoxBase<T>::isError() const
+{
+    return m_helper->isError();
+}
+
+template <typename T>
+void InlineSpinBoxBase<T>::setSymbolVisible(bool visible)
+{
+    m_helper->setSymbolVisible(visible);
+}
+
+template <typename T>
+void InlineSpinBoxBase<T>::paintEvent(QPaintEvent *event)
+{
+    T::paintEvent(event);
+
+    if (this->hasFocus() && !isError()) {
+        QPainter painter(this);
+        m_helper->drawFocusBorder(&painter, this->rect());
+    }
+}


### PR DESCRIPTION
`Undefined symbols for architecture arm64:
  "InlineSpinBoxBase<QDateTimeEdit>::InlineSpinBoxBase(QWidget*)", referenced from:
      DateTimeEdit::DateTimeEdit() in mocs_compilation.cpp.o
  "InlineSpinBoxBase<QDoubleSpinBox>::InlineSpinBoxBase(QWidget*)", referenced from:
      DoubleSpinBox::DoubleSpinBox() in mocs_compilation.cpp.o
  "InlineSpinBoxBase<QSpinBox>::InlineSpinBoxBase(QWidget*)", referenced from:
      SpinBox::SpinBox() in mocs_compilation.cpp.o
  "InlineSpinBoxBase<QDateEdit>::InlineSpinBoxBase(QWidget*)", referenced from:
      DateEdit::DateEdit() in mocs_compilation.cpp.o
  "InlineSpinBoxBase<QTimeEdit>::InlineSpinBoxBase(QWidget*)", referenced from:
      TimeEdit::TimeEdit() in mocs_compilation.cpp.o
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)`